### PR TITLE
Feature/recache payment method

### DIFF
--- a/lib/spreedly.ex
+++ b/lib/spreedly.ex
@@ -74,6 +74,11 @@ defmodule Spreedly do
     put_request(env, redact_payment_method_path(token))
   end
 
+  @spec recache_payment_method(Environment.t, String.t, String.t) :: {:ok, any} | {:error, any}
+  def recache_payment_method(env, token, verification_value) do
+    post_request(env, recache_payment_method_path(token), recache_payment_method_body(verification_value))
+  end
+
   @spec store_payment_method(Environment.t, String.t, String.t) :: {:ok, any} | {:error, any}
   def store_payment_method(env, gateway_token, payment_method_token) do
     post_request(env, store_payment_method_path(gateway_token), store_payment_method_body(payment_method_token))

--- a/lib/spreedly/path.ex
+++ b/lib/spreedly/path.ex
@@ -69,6 +69,10 @@ defmodule Spreedly.Path do
     "/payment_methods/#{token}/redact.json"
   end
 
+  def recache_payment_method_path(token) do
+    "/payment_methods/#{token}/recache.json"
+  end
+
   def store_payment_method_path(gateway_token) do
     "/gateways/#{gateway_token}/store.json"
   end

--- a/lib/spreedly/request_body.ex
+++ b/lib/spreedly/request_body.ex
@@ -52,6 +52,19 @@ defmodule Spreedly.RequestBody do
     |> Poison.encode!
   end
 
+  def recache_payment_method_body(verification_value) do
+    %{
+      payment_method:
+      %{
+        credit_card:
+        %{
+          verification_value: verification_value
+        }
+      }
+    }
+    |> Poison.encode!
+  end
+
   def store_payment_method_body(payment_method_token) do
     %{
       transaction:

--- a/test/remote/recache_payment_method_test.exs
+++ b/test/remote/recache_payment_method_test.exs
@@ -1,0 +1,26 @@
+defmodule Remote.RecachePaymentMethodTest do
+  require Logger
+  use Remote.Environment.Case
+
+  test "invalid credentials" do
+    bogus_env = Environment.new("invalid", "credentials")
+    { :error, message } = Spreedly.recache_payment_method(bogus_env, "some_card_token", 111)
+    assert message =~ "Unable to authenticate"
+  end
+
+  test "non existent" do
+    { :error, reason } = Spreedly.recache_payment_method(env(), "non_existent_card", 111)
+    assert reason =~ "Unable to find the specified payment method."
+  end
+
+  test "successfully recache" do
+    {:ok, add_trans } = Spreedly.add_credit_card(env(), card_deets())
+    assert add_trans.payment_method.storage_state == "cached"
+    {:ok, retain_trans} = Spreedly.retain_payment_method(env(), add_trans.payment_method.token)
+    assert retain_trans.payment_method.storage_state == "retained"
+    {:ok, recache_trans} = Spreedly.recache_payment_method(env(), retain_trans.payment_method.token, 111)
+    assert recache_trans.succeeded == true
+    assert recache_trans.payment_method.token == retain_trans.payment_method.token
+    assert recache_trans.transaction_type == "RecacheSensitiveData"
+  end
+end


### PR DESCRIPTION
Changes
---
Added recache payment method functionality to spreedly-elixir along with associated unit tests.

Unit Test Results
---
```
$ mix test --include remote test/remote/recache_payment_method_test.exs
Compiling 6 files (.ex)
Generated spreedly app
Including tags: [:remote]
Excluding tags: [remote: true]

...

Finished in 1.3 seconds
3 tests, 0 failures

Randomized with seed 279258
```